### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/examples/example.js
+++ b/examples/example.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const { createReadStream } = require('fs')
-const { resolve } = require('path')
+const { createReadStream } = require('node:fs')
+const { resolve } = require('node:path')
 const { fastifyThrottle } = require('../index')
 const { RandomStream } = require('../test/utils/random-stream')
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const fp = require('fastify-plugin')
 
 const { ThrottleStream } = require('./lib/throttle-stream')
-const { Readable, Stream, pipeline } = require('stream')
+const { Readable, Stream, pipeline } = require('node:stream')
 
 function fastifyThrottle (fastify, options, done) {
   options = Object.assign({}, options)

--- a/lib/throttle-stream.js
+++ b/lib/throttle-stream.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Transform } = require('stream')
+const { Transform } = require('node:stream')
 
 /**
  * The `ThrottleStream` is very similar to the node core

--- a/test/lib/throttle-stream.back-pressure.test.js
+++ b/test/lib/throttle-stream.back-pressure.test.js
@@ -5,7 +5,7 @@ const { assertTimespan } = require('../utils/assert-timespan')
 const { ThrottleStream } = require('../../lib/throttle-stream')
 const { RandomStream } = require('../utils/random-stream')
 const { SlowRandomStream } = require('../utils/slow-random-stream')
-const { pipeline } = require('stream')
+const { pipeline } = require('node:stream')
 
 test('should work as expected with a slow readable', t => {
   t.plan(3)

--- a/test/lib/throttle-stream.delay.test.js
+++ b/test/lib/throttle-stream.delay.test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { assertTimespan } = require('../utils/assert-timespan')
 const { ThrottleStream } = require('../../lib/throttle-stream')
 const { RandomStream } = require('../utils/random-stream')
-const { pipeline } = require('stream')
+const { pipeline } = require('node:stream')
 
 test('should delay the stream for 2 seconds', t => {
   t.plan(8)

--- a/test/lib/throttle-stream.resilience.test.js
+++ b/test/lib/throttle-stream.resilience.test.js
@@ -3,7 +3,7 @@
 const { test } = require('tap')
 const { ThrottleStream } = require('../../lib/throttle-stream')
 const { RandomStream } = require('../utils/random-stream')
-const { pipeline } = require('stream')
+const { pipeline } = require('node:stream')
 
 test('_init is resilient against errors', t => {
   t.plan(3)

--- a/test/lib/throttle-stream.throttling.test.js
+++ b/test/lib/throttle-stream.throttling.test.js
@@ -4,7 +4,7 @@ const { test } = require('tap')
 const { assertTimespan } = require('../utils/assert-timespan')
 const { ThrottleStream } = require('../../lib/throttle-stream')
 const { RandomStream } = require('../utils/random-stream')
-const { pipeline } = require('stream')
+const { pipeline } = require('node:stream')
 
 test('should take ~0 second to read 10,000 bytes at 10000bps', t => {
   t.plan(4)

--- a/test/utils/random-stream.js
+++ b/test/utils/random-stream.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Readable = require('stream').Readable
+const Readable = require('node:stream').Readable
 
 /**
  * Readable stream implementation that outputs random data very quickly

--- a/test/utils/slow-random-stream.js
+++ b/test/utils/slow-random-stream.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const Readable = require('stream').Readable
+const Readable = require('node:stream').Readable
 
 /**
  * Readable stream impl that outputs random data with a 100 ms delay per byte


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
