### PR TITLE
Fix four comma typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import Fastify from 'fastify'
 
 const fastify = Fastify()
 await fastify.register(import('@fastify/throttle'), {
-  bytesPerSecond: 1024 * 1024 // 1MB/s
+  bytesPerSecond: 1024 * 1024, // 1MB/s
   streamPayloads: true, // throttle the payload if it is a stream
   bufferPayloads: true, // throttle the payload if it is a Buffer
   stringPayloads: true // throttle the payload if it is a string

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ import Fastify from 'fastify'
 const fastify = Fastify()
 await fastify.register(import('@fastify/throttle'), {
   bytesPerSecond: 1024 * 1024 // 1MB/s
-  streamPayloads: true // throttle the payload if it is a stream
-  bufferPayloads: true // throttle the payload if it is a Buffer
+  streamPayloads: true, // throttle the payload if it is a stream
+  bufferPayloads: true, // throttle the payload if it is a Buffer
   stringPayloads: true // throttle the payload if it is a string
 })
 
@@ -44,8 +44,8 @@ You can pass the following options during the plugin registration:
 ```js
 await fastify.register(import('@fastify/throttle'), {
   bytesPerSecond: 1000, // 1000 bytes per second
-  streamPayloads: true // throttle the payload if it is a stream
-  bufferPayloads: true // throttle the payload if it is a Buffer
+  streamPayloads: true, // throttle the payload if it is a stream
+  bufferPayloads: true, // throttle the payload if it is a Buffer
   stringPayloads: true // throttle the payload if it is a string
 })
 ```


### PR DESCRIPTION
The documentation had a few typos that messed up syntax highlighting. This PR fixes that. (that's literally it. four missing commas.)