### PR TITLE
feat: bytesPerSecond function generated by request, allow async bytePerSecond functions

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,4 @@
 files:
   - test/**/*.test.js
+
+jobs: 1

--- a/.taprc
+++ b/.taprc
@@ -1,4 +1,2 @@
 files:
   - test/**/*.test.js
-
-jobs: 1

--- a/README.md
+++ b/README.md
@@ -101,8 +101,10 @@ Example for setting the throttling per route:
 The `bytesPerSecond` option can be a number or a function. The function for `bytesPerSecond` has the following TypeScript definition: 
 
 ```typescript
-(elapsedTime: number, bytes: number) => number
+type BytesPerSecond = (request: FastifyRequest) => ((elapsedTime: number, bytes: number) => number) | Promise<((elapsedTime: number, bytes: number) => number)>
 ```
+
+`request` is the Fastify request object.
 
 `elapsedTime` is the time since the streaming started in seconds.
 `bytes` are the bytes already sent.
@@ -120,7 +122,7 @@ the `bytesPerSecond` like this:
   fastify.get('/', {
     config: {
       throttle: {
-        bytesPerSecond: function (elapsedTime, bytes) {
+        bytesPerSecond: (request) => function (elapsedTime, bytes) {
           if (elapsedTime < 2) {
             return 0
           } else {

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ The throttle options per route are the same as the plugin options.
 
 | Header | Description | Default |
 |--------|-------------|---------|
-|`bytesPerSecond` | The allowed bytes per second, number or a function | 16384 |
-|`streamPayloads` | Throttle the payload if it is a stream | true |
-|`bufferPayloads` | Throttle the payload if it is a Buffer | false |
-|`stringPayloads` | Throttle the payload if it is a string | false |
+| `bytesPerSecond` | The allowed bytes per second, number or a function | 16384 |
+| `streamPayloads` | Throttle the payload if it is a stream | true |
+| `bufferPayloads` | Throttle the payload if it is a Buffer | false |
+| `stringPayloads` | Throttle the payload if it is a string | false |
+| `async` | Set to true if bytesPerSecond is a function returning a Promise | false |
 
 Example for setting throttling globally:
 
@@ -122,12 +123,41 @@ the `bytesPerSecond` like this:
   fastify.get('/', {
     config: {
       throttle: {
-        bytesPerSecond: (request) => function (elapsedTime, bytes) {
-          if (elapsedTime < 2) {
-            return 0
-          } else {
-            return Infinity
+        bytesPerSecond: function bytesPerSecondfactory(request) {
+          // this function runs for every request
+          const client = request.headers['customer-id']
+          
+          return function (elapsedTime, bytes) {
+            return CONFIG[client] * 2 // return a number of xyz
           }
+        }
+      }
+    }
+  }, (req, reply) => {
+    reply.send(createReadStream(resolve(__dirname, __filename)))
+  })
+
+  fastify.listen({ port: 3000 })
+```
+
+The `bytesPerSecond` function can be a sync function or an async function. If you provide an async function then it will be detected by the plugin. If it is a sync function returning a Promise, you must set the `async` option to `true`, so that the plugin knows that it should await the Promise.
+
+```js
+  const fastify = require('fastify')()
+
+  await fastify.register(import('@fastify/throttle'))
+
+  fastify.get('/', {
+    config: {
+      throttle: {
+        async: true,
+        bytesPerSecond: function bytesPerSecondfactory(request) {
+          // this function runs for every request
+          const client = request.headers['customer-id']
+          
+          return Promise.resolve(function (elapsedTime, bytes) {
+            return CONFIG[client] * 2 // return a number of xyz
+          })
         }
       }
     }

--- a/lib/is-async-function.js
+++ b/lib/is-async-function.js
@@ -1,0 +1,13 @@
+'use strict'
+
+/* istanbul ignore next */
+const AsyncFunctionConstructor = (async () => {}).constructor
+
+/**
+ * A function that returns true if the given function is an async function.
+ */
+const isAsyncFunction = (fn) => fn.constructor === AsyncFunctionConstructor
+
+module.exports = {
+  isAsyncFunction
+}

--- a/test/global-throttle.throttling.test.js
+++ b/test/global-throttle.throttling.test.js
@@ -38,3 +38,57 @@ test('should throttle globally and set the bytesPerSecond', async t => {
   await fastify.inject('/throttled')
   assertTimespan(t, startTime, Date.now(), 2000)
 })
+
+test('should throttle globally and set the bytesPerSecond function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle, {
+    bytesPerSecond: (request) => {
+      t.equal(request.headers['x-throttle-speed'], '10000')
+      const bps = parseInt(request.headers['x-throttle-speed'], 10)
+      return (elapsedTime, bytes) => {
+        return bps
+      }
+    }
+  })
+
+  fastify.get('/throttled', (req, reply) => { reply.send(new RandomStream(30000)) })
+
+  const startTime = Date.now()
+
+  await fastify.inject({
+    url: '/throttled',
+    headers: {
+      'x-throttle-speed': '10000'
+    }
+  })
+  assertTimespan(t, startTime, Date.now(), 2000)
+})
+
+test('should throttle globally and set the bytesPerSecond async function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle, {
+    bytesPerSecond: async (request) => {
+      t.equal(request.headers['x-throttle-speed'], '10000')
+      const bps = parseInt(request.headers['x-throttle-speed'], 10)
+      return (elapsedTime, bytes) => {
+        return bps
+      }
+    }
+  })
+
+  fastify.get('/throttled', (req, reply) => { reply.send(new RandomStream(30000)) })
+
+  const startTime = Date.now()
+
+  await fastify.inject({
+    url: '/throttled',
+    headers: {
+      'x-throttle-speed': '10000'
+    }
+  })
+  assertTimespan(t, startTime, Date.now(), 2000)
+})

--- a/test/lib/is-async-function.test.js
+++ b/test/lib/is-async-function.test.js
@@ -1,0 +1,14 @@
+'use strict'
+
+const { test } = require('tap')
+const { isAsyncFunction } = require('../../lib/is-async-function.js')
+
+test('isAsyncFunction returns true for async functions', (t) => {
+  t.plan(1)
+  t.ok(isAsyncFunction(async () => { }))
+})
+
+test('isAsyncFunction returns false for non-async functions', (t) => {
+  t.plan(1)
+  t.notOk(isAsyncFunction(() => { }))
+})

--- a/test/route-throttle.buffer-payloads.test.js
+++ b/test/route-throttle.buffer-payloads.test.js
@@ -70,3 +70,47 @@ test('should throttle Buffer payloads if bufferPayloads is set to true', async t
   assertTimespan(t, startTime, Date.now(), 2000)
   t.equal(response.body.length, 3000)
 })
+
+test('should throttle Buffer payloads if bufferPayloads is set to true and bytesPerSecond is a function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: (request) => (elapsedTime, bytes) => 1000,
+        bufferPayloads: true
+      }
+    }
+  }, (req, reply) => { reply.send(Buffer.alloc(3000)) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/throttled')
+  assertTimespan(t, startTime, Date.now(), 2000)
+  t.equal(response.body.length, 3000)
+})
+
+test('should throttle Buffer payloads if bufferPayloads is set to true and bytesPerSecond is an async function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: async (request) => (elapsedTime, bytes) => 1000,
+        bufferPayloads: true
+      }
+    }
+  }, (req, reply) => { reply.send(Buffer.alloc(3000)) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/throttled')
+  assertTimespan(t, startTime, Date.now(), 2000)
+  t.equal(response.body.length, 3000)
+})

--- a/test/route-throttle.stream-payloads.test.js
+++ b/test/route-throttle.stream-payloads.test.js
@@ -50,6 +50,50 @@ test('should throttle streams payloads if streamPayloads is set to true', async 
   t.equal(response.body.length, 3000)
 })
 
+test('should throttle streams payloads if streamPayloads is set to true and bytesPerSecond is a function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: (request) => (elapsedTime, bytes) => 1000,
+        streamPayloads: true
+      }
+    }
+  }, (req, reply) => { reply.send(new RandomStream(3000)) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/throttled')
+  assertTimespan(t, startTime, Date.now(), 2000)
+  t.equal(response.body.length, 3000)
+})
+
+test('should throttle streams payloads if streamPayloads is set to true and bytesPerSecond is an async function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: async (request) => (elapsedTime, bytes) => 1000,
+        streamPayloads: true
+      }
+    }
+  }, (req, reply) => { reply.send(new RandomStream(3000)) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/throttled')
+  assertTimespan(t, startTime, Date.now(), 2000)
+  t.equal(response.body.length, 3000)
+})
+
 test('should not throttle streams payloads if streamPayloads is set to false', async t => {
   t.plan(2)
   const fastify = Fastify()
@@ -60,6 +104,28 @@ test('should not throttle streams payloads if streamPayloads is set to false', a
     config: {
       throttle: {
         bytesPerSecond: 1000,
+        streamPayloads: false
+      }
+    }
+  }, (req, reply) => { reply.send(new RandomStream(3000)) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/')
+  assertTimespan(t, startTime, Date.now(), 50, 100)
+  t.equal(response.body.length, 3000)
+})
+
+test('should not throttle streams payloads if streamPayloads is set to false', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/', {
+    config: {
+      throttle: {
+        bytesPerSecond: (request) => (elapsedTime, bytes) => 1000,
         streamPayloads: false
       }
     }

--- a/test/route-throttle.string-payloads.test.js
+++ b/test/route-throttle.string-payloads.test.js
@@ -70,3 +70,47 @@ test('should throttle string payloads when stringPayloads is true', async t => {
   assertTimespan(t, startTime, Date.now(), 2000)
   t.equal(response.body.length, 3000)
 })
+
+test('should throttle string payloads when stringPayloads is true and bytesPerSecond is a function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: (request) => (elapsedTime, bytes) => 1000,
+        stringPayloads: true
+      }
+    }
+  }, (req, reply) => { reply.send(Buffer.alloc(3000).toString()) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/throttled')
+  assertTimespan(t, startTime, Date.now(), 2000)
+  t.equal(response.body.length, 3000)
+})
+
+test('should throttle string payloads when stringPayloads is true and bytesPerSecond is an async function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: async (request) => (elapsedTime, bytes) => 1000,
+        stringPayloads: true
+      }
+    }
+  }, (req, reply) => { reply.send(Buffer.alloc(3000).toString()) })
+
+  const startTime = Date.now()
+
+  const response = await fastify.inject('/throttled')
+  assertTimespan(t, startTime, Date.now(), 2000)
+  t.equal(response.body.length, 3000)
+})

--- a/test/route-throttle.throttling.test.js
+++ b/test/route-throttle.throttling.test.js
@@ -46,3 +46,65 @@ test('should throttle per route and set the bytesPerSecond', async t => {
   await fastify.inject('/throttled')
   assertTimespan(t, startTime, Date.now(), 2000)
 })
+
+test('should throttle per route and set the bytesPerSecond as function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: (request) => {
+          t.equal(request.headers['x-throttle-speed'], '10000')
+          const bps = parseInt(request.headers['x-throttle-speed'], 10)
+          return (elapsedTime, bytes) => {
+            return bps
+          }
+        }
+      }
+    }
+  }, (req, reply) => { reply.send(new RandomStream(30000)) })
+
+  const startTime = Date.now()
+
+  await fastify.inject({
+    url: '/throttled',
+    headers: {
+      'x-throttle-speed': '10000'
+    }
+  })
+  assertTimespan(t, startTime, Date.now(), 2000)
+})
+
+test('should throttle per route and set the bytesPerSecond as async function', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  await fastify.register(fastifyThrottle)
+
+  fastify.get('/throttled', {
+    config: {
+      throttle: {
+        bytesPerSecond: async (request) => {
+          t.equal(request.headers['x-throttle-speed'], '10000')
+          const bps = parseInt(request.headers['x-throttle-speed'], 10)
+          return (elapsedTime, bytes) => {
+            return bps
+          }
+        }
+      }
+    }
+  }, (req, reply) => { reply.send(new RandomStream(30000)) })
+
+  const startTime = Date.now()
+
+  await fastify.inject({
+    url: '/throttled',
+    headers: {
+      'x-throttle-speed': '10000'
+    }
+  })
+  assertTimespan(t, startTime, Date.now(), 2000)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -64,6 +64,13 @@ declare namespace fastifyThrottle {
      * @default false
      */
     stringPayloads?: boolean
+
+    /**
+     * The bytesPerSecond function is a sync function returning a Promise.
+     * @type {boolean}
+     * @default false
+     */
+    async?: boolean;
   }
 
   export interface FastifyThrottlePluginOptions extends FastifyThrottleOptions {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import {
-  FastifyPluginCallback,
+  FastifyPluginCallback, FastifyRequest,
 } from 'fastify';
 
 declare module 'fastify' {
@@ -20,6 +20,11 @@ type FastifyThrottle = FastifyPluginCallback<fastifyThrottle.FastifyThrottleOpti
 type BytesPerSecondFn = (elapsedTime: number, bytes: number) => number
 
 /**
+ * Represents a function that generates a BytesPerSecondFn.
+ */
+type BytesPerSecondGenerator = (request: FastifyRequest) => BytesPerSecondFn | Promise<BytesPerSecondFn>
+
+/**
  * Namespace for fastify-throttle plugin options.
  *
  * @namespace fastifyThrottle
@@ -37,7 +42,7 @@ declare namespace fastifyThrottle {
      * @type {number|BytesPerSecondFn}
      * @default 16384
      */
-    bytesPerSecond: number | BytesPerSecondFn
+    bytesPerSecond: number | BytesPerSecondGenerator
 
     /**
      * Throttle stream payloads.

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import fastify from 'fastify'
+import fastify, { FastifyRequest } from 'fastify'
 import fastifyThrottle from '..'
 import { expectType } from 'tsd';
 
@@ -11,10 +11,24 @@ server.register(fastifyThrottle, {
   stringPayloads: false
 })
 server.register(fastifyThrottle, {
-  bytesPerSecond: (elapsedTime, bytes) => {
-    expectType<number>(elapsedTime)
-    expectType<number>(bytes)
-    return 200
+  bytesPerSecond: (_req) => {
+    expectType<FastifyRequest>(_req)
+    return (elapsedTime, bytes) => {
+      expectType<number>(elapsedTime)
+      expectType<number>(bytes)
+      return 200
+    }
+  }
+})
+
+server.register(fastifyThrottle, {
+  bytesPerSecond: async (_req) => {
+    expectType<FastifyRequest>(_req)
+    return (elapsedTime, bytes) => {
+      expectType<number>(elapsedTime)
+      expectType<number>(bytes)
+      return 200
+    }
   }
 })
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -32,6 +32,18 @@ server.register(fastifyThrottle, {
   }
 })
 
+server.register(fastifyThrottle, {
+  async: true,
+  bytesPerSecond: (_req) => {
+    expectType<FastifyRequest>(_req)
+    return Promise.resolve((elapsedTime, bytes) => {
+      expectType<number>(elapsedTime)
+      expectType<number>(bytes)
+      return 200
+    })
+  }
+})
+
 server.get('/', {
   config: {
     throttle: {


### PR DESCRIPTION
Resolves #7 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
