### PR TITLE
fix: add check on the pipeline callback `err` parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ async function addRouteThrottleHook (fastify, routeOptions, throttleOptions) {
 
 function throttleOnSendHandler (fastify, throttleOpts) {
   const bytesPerSecond = throttleOpts.bytesPerSecond
+  const pipelineErrorCallback = err => { if (err) fastify.log.error(err) }
 
   if (typeof bytesPerSecond === 'number') {
     return async function onSendHandler (request, reply, payload) {
@@ -44,21 +45,21 @@ function throttleOnSendHandler (fastify, throttleOpts) {
         return pipeline(
           payload,
           new ThrottleStream({ bytesPerSecond }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       if (throttleOpts.bufferPayloads && Buffer.isBuffer(payload)) {
         return pipeline(
           Readable.from(payload),
           new ThrottleStream({ bytesPerSecond }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       if (throttleOpts.stringPayloads && typeof payload === 'string') {
         return pipeline(
           Readable.from(Buffer.from(payload)),
           new ThrottleStream({ bytesPerSecond }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       return payload
@@ -69,21 +70,21 @@ function throttleOnSendHandler (fastify, throttleOpts) {
         return pipeline(
           payload,
           new ThrottleStream({ bytesPerSecond: await bytesPerSecond(request) }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       if (throttleOpts.bufferPayloads && Buffer.isBuffer(payload)) {
         return pipeline(
           Readable.from(payload),
           new ThrottleStream({ bytesPerSecond: await bytesPerSecond(request) }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       if (throttleOpts.stringPayloads && typeof payload === 'string') {
         return pipeline(
           Readable.from(Buffer.from(payload)),
           new ThrottleStream({ bytesPerSecond: await bytesPerSecond(request) }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       return payload
@@ -94,21 +95,21 @@ function throttleOnSendHandler (fastify, throttleOpts) {
         return pipeline(
           payload,
           new ThrottleStream({ bytesPerSecond: bytesPerSecond(request) }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       if (throttleOpts.bufferPayloads && Buffer.isBuffer(payload)) {
         return pipeline(
           Readable.from(payload),
           new ThrottleStream({ bytesPerSecond: bytesPerSecond(request) }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       if (throttleOpts.stringPayloads && typeof payload === 'string') {
         return pipeline(
           Readable.from(Buffer.from(payload)),
           new ThrottleStream({ bytesPerSecond: bytesPerSecond(request) }),
-          err => { fastify.log.error(err) }
+          pipelineErrorCallback
         )
       }
       return payload

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ async function addRouteThrottleHook (fastify, routeOptions, throttleOptions) {
 
 function throttleOnSendHandler (fastify, throttleOpts) {
   const bytesPerSecond = throttleOpts.bytesPerSecond
-  const pipelineErrorCallback = err => { if (err) fastify.log.error(err) }
+  const pipelineCallback = err => err && fastify.log.error(err)
 
   if (typeof bytesPerSecond === 'number') {
     return async function onSendHandler (request, reply, payload) {
@@ -45,21 +45,21 @@ function throttleOnSendHandler (fastify, throttleOpts) {
         return pipeline(
           payload,
           new ThrottleStream({ bytesPerSecond }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       if (throttleOpts.bufferPayloads && Buffer.isBuffer(payload)) {
         return pipeline(
           Readable.from(payload),
           new ThrottleStream({ bytesPerSecond }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       if (throttleOpts.stringPayloads && typeof payload === 'string') {
         return pipeline(
           Readable.from(Buffer.from(payload)),
           new ThrottleStream({ bytesPerSecond }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       return payload
@@ -70,21 +70,21 @@ function throttleOnSendHandler (fastify, throttleOpts) {
         return pipeline(
           payload,
           new ThrottleStream({ bytesPerSecond: await bytesPerSecond(request) }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       if (throttleOpts.bufferPayloads && Buffer.isBuffer(payload)) {
         return pipeline(
           Readable.from(payload),
           new ThrottleStream({ bytesPerSecond: await bytesPerSecond(request) }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       if (throttleOpts.stringPayloads && typeof payload === 'string') {
         return pipeline(
           Readable.from(Buffer.from(payload)),
           new ThrottleStream({ bytesPerSecond: await bytesPerSecond(request) }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       return payload
@@ -95,21 +95,21 @@ function throttleOnSendHandler (fastify, throttleOpts) {
         return pipeline(
           payload,
           new ThrottleStream({ bytesPerSecond: bytesPerSecond(request) }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       if (throttleOpts.bufferPayloads && Buffer.isBuffer(payload)) {
         return pipeline(
           Readable.from(payload),
           new ThrottleStream({ bytesPerSecond: bytesPerSecond(request) }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       if (throttleOpts.stringPayloads && typeof payload === 'string') {
         return pipeline(
           Readable.from(Buffer.from(payload)),
           new ThrottleStream({ bytesPerSecond: bytesPerSecond(request) }),
-          pipelineErrorCallback
+          pipelineCallback
         )
       }
       return payload

--- a/test/error.throttling.test.js
+++ b/test/error.throttling.test.js
@@ -1,0 +1,60 @@
+'use strict'
+
+const t = require('tap')
+const test = t.test
+const Fastify = require('fastify')
+const { fastifyThrottle } = require('../index')
+const { assertTimespan } = require('./utils/assert-timespan')
+const { RandomStream } = require('./utils/random-stream')
+const { ErrorStream } = require('./utils/error-stream')
+const { CustomLogger } = require('./utils/logger')
+
+test('stream (no error)', async t => {
+  t.plan(1)
+  const fastify = Fastify({
+    logger: new CustomLogger((err) => {
+      t.error(err)
+    })
+  })
+
+  await fastify.register(fastifyThrottle, {
+    bytesPerSecond: 1000
+  })
+
+  fastify.get('/throttled', (req, reply) => { reply.send(new RandomStream(3000)) })
+
+  const startTime = Date.now()
+
+  await fastify.inject({
+    url: '/throttled'
+  })
+
+  assertTimespan(t, startTime, Date.now(), 2000)
+})
+
+test('stream (error)', async t => {
+  t.plan(4)
+  const message = 'failed stream'
+  const fastify = Fastify({
+    logger: new CustomLogger({
+      error: (data) => {
+        // This function gets called twice
+        // Once by fastify and once by the failed pipeline
+        const err = data?.err ?? data
+
+        t.type(err, Error)
+        t.same(err.message, message)
+      }
+    })
+  })
+
+  await fastify.register(fastifyThrottle, {
+    bytesPerSecond: 1000
+  })
+
+  fastify.get('/throttled', (req, reply) => { reply.send(new ErrorStream(message)) })
+
+  await fastify.inject({
+    url: '/throttled'
+  })
+})

--- a/test/utils/error-stream.js
+++ b/test/utils/error-stream.js
@@ -20,7 +20,7 @@ class ErrorStream extends Readable {
   }
 
   _read () {
-    throw new Error(this.#message)
+    this.emit('error', new Error(this.#message))
   }
 }
 

--- a/test/utils/error-stream.js
+++ b/test/utils/error-stream.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const Readable = require('node:stream').Readable
+
+/**
+ * Readable stream implementation which trhows an Error with the specified message
+ */
+class ErrorStream extends Readable {
+  /**
+   * @type {string}
+   */
+  #message
+
+  /**
+   * @param {string} message
+   */
+  constructor (message) {
+    super()
+    this.#message = message
+  }
+
+  _read () {
+    throw new Error(this.#message)
+  }
+}
+
+module.exports = {
+  ErrorStream
+}

--- a/test/utils/error-stream.js
+++ b/test/utils/error-stream.js
@@ -20,7 +20,7 @@ class ErrorStream extends Readable {
   }
 
   _read () {
-    this.emit('error', new Error(this.#message))
+    this.destroy(new Error(this.#message))
   }
 }
 

--- a/test/utils/logger.js
+++ b/test/utils/logger.js
@@ -1,0 +1,119 @@
+'use strict'
+
+/**
+ * Custom logger implementation useful to check if the various logging
+ * functions get called and check their content
+ */
+class CustomLogger {
+  /**
+   * @type {undefined | (...data: any[]) => void}
+   */
+  #infoFn
+
+  /**
+   * @type {undefined | (...data: any[]) => void}
+   */
+  #debugFn
+
+  /**
+   * @type {undefined | (...data: any[]) => void}
+   */
+  #fatalFn
+
+  /**
+   * @type {undefined | (...data: any[]) => void}
+   */
+  #warnFn
+
+  /**
+   * @type {undefined | (...data: any[]) => void}
+   */
+  #traceFn
+
+  /**
+   * @type {undefined | (...data: any[]) => CustomLogger}
+  */
+  #childFn
+
+  /**
+  * @type {undefined | (...data: any[]) => void}
+  */
+  #errFn
+
+  /**
+   * @param {object} param
+   * @param {undefined | (...data: any[]) => void} param.info
+   * @param {undefined | (...data: any[]) => void} param.debug
+   * @param {undefined | (...data: any[]) => void} param.fatal
+   * @param {undefined | (...data: any[]) => void} param.warn
+   * @param {undefined | (...data: any[]) => void} param.info
+   * @param {undefined | (...data: any[]) => void} param.trace
+   * @param {undefined | (...data: any[]) => CustomLogger} param.child
+   * @param {undefined | (...data: any[]) => void} param.error
+ì   */
+  constructor ({
+    info,
+    debug,
+    fatal,
+    warn,
+    trace,
+    child,
+    error
+  }) {
+    this.#infoFn = info
+    this.#debugFn = debug
+    this.#fatalFn = fatal
+    this.#warnFn = warn
+    this.#traceFn = trace
+    this.#childFn = child
+    this.#errFn = error
+  }
+
+  info (...data) {
+    if (this.#infoFn) {
+      return this.#infoFn(...data)
+    }
+  }
+
+  debug (...data) {
+    if (this.#debugFn) {
+      return this.#infoFn(...data)
+    }
+  }
+
+  fatal (...data) {
+    if (this.#fatalFn) {
+      return this.#infoFn(...data)
+    }
+  }
+
+  warn (...data) {
+    if (this.#warnFn) {
+      return this.#infoFn(...data)
+    }
+  }
+
+  trace (...data) {
+    if (this.#traceFn) {
+      return this.#infoFn(...data)
+    }
+  }
+
+  child (...data) {
+    if (this.#childFn) {
+      return this.#infoFn(...data)
+    }
+
+    return this
+  }
+
+  error (...data) {
+    if (this.#errFn) {
+      return this.#errFn(...data)
+    }
+  }
+}
+
+module.exports = {
+  CustomLogger
+}


### PR DESCRIPTION
This PR adds the check on the `err` parameter of the pipeline callback to verify whether an error was raised or the pipeline finished successfully.

Closes #14 

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
